### PR TITLE
Made update internal configurable

### DIFF
--- a/custom_components/systemair/config_flow.py
+++ b/custom_components/systemair/config_flow.py
@@ -45,6 +45,8 @@ from .const import (
     SERIAL_BYTESIZES,
     SERIAL_PARITIES,
     SERIAL_STOPBITS,
+    CONF_UPDATE_INTERVAL, 
+    DEFAULT_UPDATE_INTERVAL,
 )
 
 
@@ -339,14 +341,24 @@ class SystemairOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         default_model = self.config_entry.options.get(CONF_MODEL, self.config_entry.data.get(CONF_MODEL, "VSR 300"))
+        default_update_interval = self.config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
         api_type = self.config_entry.data.get(CONF_API_TYPE)
 
-        # Base schema with model selection
+        # Base schema with model selection and update interval
         schema_dict = {
             vol.Required(CONF_MODEL, default=default_model): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=list(MODEL_SPECS.keys()),
                     mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(CONF_UPDATE_INTERVAL, default=default_update_interval): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=10,
+                    max=300,
+                    step=1,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
                 )
             ),
         }

--- a/custom_components/systemair/const.py
+++ b/custom_components/systemair/const.py
@@ -16,6 +16,10 @@ DEFAULT_PORT = 502
 DEFAULT_SLAVE_ID = 1
 DEFAULT_WEB_API_MAX_REGISTERS = 70
 
+# --- Making update interval configurable ---
+CONF_UPDATE_INTERVAL = "update_interval"
+DEFAULT_UPDATE_INTERVAL = 60
+
 # --- API Types ---
 API_TYPE_MODBUS_TCP = "modbus_tcp"
 API_TYPE_MODBUS_WEBAPI = "modbus_webapi"

--- a/custom_components/systemair/coordinator.py
+++ b/custom_components/systemair/coordinator.py
@@ -14,7 +14,14 @@ from .api import (
     SystemairClientBase,
     SystemairWebApiClient,
 )
-from .const import DOMAIN, LOGGER
+
+from .const import (
+    DOMAIN, 
+    LOGGER, 
+    CONF_UPDATE_INTERVAL, 
+    DEFAULT_UPDATE_INTERVAL
+)
+
 from .modbus import IntegerType, parameter_map
 
 if TYPE_CHECKING:
@@ -50,11 +57,14 @@ class SystemairDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self.modbus_parameters: list[ModbusParameter] = []
 
+        # Get update interval from options, fallback to default
+        update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+
         super().__init__(
             hass=hass,
             logger=LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=10),
+            update_interval=timedelta(seconds=update_interval),
         )
 
     def register_modbus_parameters(self, modbus_parameter: ModbusParameter) -> None:


### PR DESCRIPTION
Change to allow the update interval to be configurable and a default of 60 seconds.  My VTR300 was regularly hanging with the original default of 10 seconds.