### PR TITLE
Resolved issue with Free Cooling not working

### DIFF
--- a/custom_components/systemair/const.py
+++ b/custom_components/systemair/const.py
@@ -18,10 +18,6 @@ DEFAULT_SLAVE_ID = 1
 DEFAULT_WEB_API_MAX_REGISTERS = 70
 DEFAULT_UPDATE_INTERVAL = 60
 
-# --- Making update interval configurable ---
-CONF_UPDATE_INTERVAL = "update_interval"
-DEFAULT_UPDATE_INTERVAL = 60
-
 # --- API Types ---
 API_TYPE_MODBUS_TCP = "modbus_tcp"
 API_TYPE_MODBUS_WEBAPI = "modbus_webapi"


### PR DESCRIPTION
Some of the registers were missing in the api.py have reviewed modbus.py and ensured they are now all included in the api.py read blocks.