### PR TITLE
Add REG_SENSOR_MODBUS_CO2 and REG_SENSOR_MODBUS_RHS as writable number entities

### DIFF
--- a/custom_components/systemair/number.py
+++ b/custom_components/systemair/number.py
@@ -9,7 +9,13 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -229,6 +235,26 @@ NUMBERS: tuple[SystemairNumberEntityDescription, ...] = (
         mode=NumberMode.BOX,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         registry=parameter_map["REG_EXTRA_CONTROLLER_CIRC_PUMP_STOP_DELAY"],
+    ),
+    SystemairNumberEntityDescription(
+        key="modbus_co2_input",
+        translation_key="modbus_co2_input",
+        device_class=NumberDeviceClass.CO2,
+        native_step=1,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        icon="mdi:molecule-co2",
+        registry=parameter_map["REG_SENSOR_MODBUS_CO2"],
+    ),
+    SystemairNumberEntityDescription(
+        key="modbus_rh_input",
+        translation_key="modbus_rh_input",
+        device_class=NumberDeviceClass.HUMIDITY,
+        native_step=1,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:water-percent",
+        registry=parameter_map["REG_SENSOR_MODBUS_RHS"],
     ),
 )
 

--- a/custom_components/systemair/translations/en.json
+++ b/custom_components/systemair/translations/en.json
@@ -228,6 +228,12 @@
             },
             "extra_controller_circ_pump_stop_delay": {
                 "name": "Extra Controller Circulation Pump: Stop Delay"
+            },
+            "modbus_co2_input": {
+                "name": "Modbus CO2 Input"
+            },
+            "modbus_rh_input": {
+                "name": "Modbus Humidity Input"
             }
         },
         "sensor": {


### PR DESCRIPTION
## Summary

- Expose **REG_SENSOR_MODBUS_CO2** (register 12113, 0–2000 ppm) and **REG_SENSOR_MODBUS_RHS** (register 12114, 0–100%) as writable `number` entities
- Both registers are already defined in `modbus.py` as Holding registers (R/W) but were not previously available as Home Assistant entities
- Adds corresponding translation keys in `translations/en.json`

## Use case

These registers allow feeding **external sensor readings** into the ventilation unit's demand control algorithm. Per the official *Systemair SAVE Modbus Variable List* (Rev 36), register 12113 is documented as *"Set a virtual CO2 sensor reading"* and register 12114 as *"Set a virtual RH sensor reading"*.

The unit's demand controller uses the **highest value** from all CO2/RH sources (physical duct sensor + this virtual Modbus input), so writing an external room sensor value here enables demand-controlled ventilation based on actual room air quality — even without a wired duct sensor.

**Key property**: These registers are **volatile** (RAM only, no EEPROM wear), so frequent writes from an automation (e.g., every 60s from an external CO2 sensor) are safe and expected.

### Example automation

An external CO2 sensor (e.g., Sonoff SNZB-06P via Zigbee/Matter) writes its reading to the ventilation unit every minute:

```yaml
automation:
  - alias: "Feed CO2 to Systemair"
    trigger:
      - platform: state
        entity_id: sensor.room_co2
    action:
      - service: number.set_value
        target:
          entity_id: number.systemair_modbus_co2_input
        data:
          value: "{{ states('sensor.room_co2') | int(0) }}"
```

## Changes

| File | Change |
|------|--------|
| `number.py` | Added two `SystemairNumberEntityDescription` entries for CO2 (ppm, `NumberDeviceClass.CO2`) and RH (%, `NumberDeviceClass.HUMIDITY`) |
| `translations/en.json` | Added `"modbus_co2_input"` and `"modbus_rh_input"` translation keys |

No changes to `modbus.py` (registers already defined), `api.py`, or `homesolution.py` — the existing `write_register` / `set_modbus_data` path handles these correctly for all connection types (Modbus TCP, Serial, WebAPI, HomeSolution).

## Test plan

- [ ] Verify entities appear after integration reload (number.systemair_modbus_co2_input, number.systemair_modbus_rh_input)
- [ ] Verify min/max values are correctly applied (0–2000 for CO2, 0–100 for RH)
- [ ] Write a value via `number.set_value` service and confirm it is reflected on the unit
- [ ] Confirm the unit's demand controller picks up the written value as the highest CO2/RH source

🤖 Generated with [Claude Code](https://claude.com/claude-code)