### PR TITLE
fix: support HA 2026.7 pymodbus requirements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v6
           with:
-            python-version: "3.13"
+            python-version: "3.14.6"
             cache: "pip"
 
         - name: "Install requirements"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Set up Python"
         uses: "actions/setup-python@v6"
         with:
-          python-version: '3.12'
+          python-version: '3.14.6'
 
       - name: "Install dependencies"
         run: pip install ruff

--- a/custom_components/systemair/manifest.json
+++ b/custom_components/systemair/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/AN3Orik/systemair/issues",
   "requirements": [
-    "pymodbus==3.11.2",
+    "pymodbus>=3.11.2,<3.14",
     "aiohttp",
     "async-timeout"
   ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog>=6.10.1
-homeassistant==2025.9.4
+homeassistant==2026.6.4
 pip>=26.1.2
 ruff>=0.15.18

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for the Systemair integration."""

--- a/tests/test_manifest_requirements.py
+++ b/tests/test_manifest_requirements.py
@@ -1,3 +1,5 @@
+"""Regression tests for package requirements declared in the integration manifest."""
+
 from __future__ import annotations
 
 import json
@@ -18,11 +20,10 @@ def _pymodbus_requirement() -> str:
 
 
 def _allows_version(requirement: str, version: str) -> bool:
-    specifiers = requirement.removeprefix("pymodbus").split(",")
     version_tuple = _version_tuple(version)
 
-    for specifier in specifiers:
-        specifier = specifier.strip()
+    for raw_specifier in requirement.removeprefix("pymodbus").split(","):
+        specifier = raw_specifier.strip()
         if not specifier:
             continue
 
@@ -46,23 +47,26 @@ def _allows_version(requirement: str, version: str) -> bool:
                 return False
             continue
 
-        if specifier.startswith("<"):
-            if version_tuple >= _version_tuple(specifier[1:]):
-                return False
+        if specifier.startswith("<") and version_tuple >= _version_tuple(specifier[1:]):
+            return False
 
     return True
 
 
 class ManifestRequirementsTest(unittest.TestCase):
+    """Regression coverage for the integration manifest requirements."""
+
     def test_pymodbus_requirement_allows_supported_versions(self) -> None:
+        """The manifest must allow both currently supported Home Assistant dependency sets."""
         requirement = _pymodbus_requirement()
 
-        self.assertTrue(_allows_version(requirement, "3.11.2"))
-        self.assertTrue(_allows_version(requirement, "3.13.1"))
+        assert _allows_version(requirement, "3.11.2")  # noqa: S101
+        assert _allows_version(requirement, "3.13.1")  # noqa: S101
 
     def test_pymodbus_requirement_rejects_unsupported_older_versions(self) -> None:
+        """The manifest should not widen support below the declared Home Assistant baseline."""
         requirement = _pymodbus_requirement()
 
-        self.assertFalse(_allows_version(requirement, "3.11.1"))
-        self.assertFalse(_allows_version(requirement, "3.9.2"))
-        self.assertFalse(_allows_version(requirement, "3.14.0"))
+        assert not _allows_version(requirement, "3.11.1")  # noqa: S101
+        assert not _allows_version(requirement, "3.9.2")  # noqa: S101
+        assert not _allows_version(requirement, "3.14.0")  # noqa: S101

--- a/tests/test_manifest_requirements.py
+++ b/tests/test_manifest_requirements.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+MANIFEST_PATH = Path("custom_components/systemair/manifest.json")
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def _pymodbus_requirement() -> str:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return next(requirement for requirement in manifest["requirements"] if requirement.startswith("pymodbus"))
+
+
+def _allows_version(requirement: str, version: str) -> bool:
+    specifiers = requirement.removeprefix("pymodbus").split(",")
+    version_tuple = _version_tuple(version)
+
+    for specifier in specifiers:
+        specifier = specifier.strip()
+        if not specifier:
+            continue
+
+        if specifier.startswith("=="):
+            if version_tuple != _version_tuple(specifier[2:]):
+                return False
+            continue
+
+        if specifier.startswith(">="):
+            if version_tuple < _version_tuple(specifier[2:]):
+                return False
+            continue
+
+        if specifier.startswith("<="):
+            if version_tuple > _version_tuple(specifier[2:]):
+                return False
+            continue
+
+        if specifier.startswith(">"):
+            if version_tuple <= _version_tuple(specifier[1:]):
+                return False
+            continue
+
+        if specifier.startswith("<"):
+            if version_tuple >= _version_tuple(specifier[1:]):
+                return False
+
+    return True
+
+
+class ManifestRequirementsTest(unittest.TestCase):
+    def test_pymodbus_requirement_allows_supported_versions(self) -> None:
+        requirement = _pymodbus_requirement()
+
+        self.assertTrue(_allows_version(requirement, "3.11.2"))
+        self.assertTrue(_allows_version(requirement, "3.13.1"))
+
+    def test_pymodbus_requirement_rejects_unsupported_older_versions(self) -> None:
+        requirement = _pymodbus_requirement()
+
+        self.assertFalse(_allows_version(requirement, "3.11.1"))
+        self.assertFalse(_allows_version(requirement, "3.9.2"))

--- a/tests/test_manifest_requirements.py
+++ b/tests/test_manifest_requirements.py
@@ -65,3 +65,4 @@ class ManifestRequirementsTest(unittest.TestCase):
 
         self.assertFalse(_allows_version(requirement, "3.11.1"))
         self.assertFalse(_allows_version(requirement, "3.9.2"))
+        self.assertFalse(_allows_version(requirement, "3.14.0"))

--- a/tests/test_manifest_requirements.py
+++ b/tests/test_manifest_requirements.py
@@ -6,7 +6,6 @@ import json
 import unittest
 from pathlib import Path
 
-
 MANIFEST_PATH = Path("custom_components/systemair/manifest.json")
 
 


### PR DESCRIPTION
## Summary
- relax the `pymodbus` requirement to support both Home Assistant 2026.6.x and 2026.7.x dependency sets
- pin local development to the latest stable non-beta Home Assistant release
- add a regression test for the manifest requirement range

## Impact
- Affected connection modes: Modbus TCP, RS485
- Web API mode: not affected by the runtime dependency change
- Config flow updates: none
- Translation updates: none

Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened compatibility for a core dependency by switching from an exact version pin to a supported version range.
  * Updated dependency pins to newer approved versions.
* **Tests**
  * Added regression coverage to verify the integration’s declared dependency version constraints accept supported versions and reject unsupported ones.
* **Chores**
  * Updated CI linting environment to use Python 3.14.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->