### PR TITLE
add undeclared requirements

### DIFF
--- a/custom_components/systemair/manifest.json
+++ b/custom_components/systemair/manifest.json
@@ -11,7 +11,9 @@
   "requirements": [
     "pymodbus>=3.11.2,<3.14",
     "aiohttp",
-    "async-timeout"
+    "async-timeout",
+    "beautifulsoup4",
+    "websocket-client",
   ],
   "version": "1.0.28"
 }

--- a/custom_components/systemair/manifest.json
+++ b/custom_components/systemair/manifest.json
@@ -13,7 +13,7 @@
     "aiohttp",
     "async-timeout",
     "beautifulsoup4",
-    "websocket-client",
+    "websocket-client"
   ],
   "version": "1.0.28"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Systemair integration’s setup requirements to improve compatibility by keeping `async-timeout` and adding `beautifulsoup4` and `websocket-client`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->