### PR TITLE
fix: restore HomeSolution polling and fan control

### DIFF
--- a/custom_components/systemair/homesolution.py
+++ b/custom_components/systemair/homesolution.py
@@ -208,10 +208,13 @@ class SystemairHomeSolutionClient(SystemairClientBase):
     async def get_all_data(
         self,
         *,
-        _enable_alarm_details: bool = True,
-        _enable_alarm_history: bool = False,
+        enable_alarm_details: bool = True,
+        enable_alarm_history: bool = False,
     ) -> VentilationUnit:
         """Get all data."""
+        # HomeSolution discovers alarm capabilities through the same view catalog;
+        # these options remain part of the shared Systemair client contract.
+        del enable_alarm_details, enable_alarm_history
         if self._rate_limit_until > monotonic() and self.unit is not None and self.unit.registers:
             return self.unit
 

--- a/custom_components/systemair/homesolution_mapping.py
+++ b/custom_components/systemair/homesolution_mapping.py
@@ -48,9 +48,6 @@ HOMESOLUTION_WRITE_CAPABILITY_ALIASES: dict[str, dict[str, str]] = {
     "REG_USERMODE_HMI_CHANGE_REQUEST": {
         "REG_MAINBOARD_USERMODE_HMI_CHANGE_REQUEST": "REG_MAINBOARD_USERMODE_MODE_HMI",
     },
-    "REG_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF": {
-        "REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF": "REG_MAINBOARD_SPEED_INDICATION_APP",
-    },
     "REG_FILTER_PERIOD": {
         "REG_MAINBOARD_FILTER_PERIOD_SET": "REG_MAINBOARD_FILTER_PERIOD",
     },
@@ -125,15 +122,13 @@ def _speed_indication_to_save_fan_mode(value: Any) -> int | None:
 
 
 def _resolve_fan_mode_register(unit: VentilationUnit) -> float | None:
-    """Resolve the action/readback airflow enums to SAVE Climate values."""
+    """Resolve the selected fan mode, falling back to delayed actual airflow."""
+    if (action := unit.registers.get(RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF)) is not None:
+        value = _speed_indication_to_save_fan_mode(action)
+        return None if value is None else float(value)
     if (readback := unit.registers.get(RegisterConstants.REG_MAINBOARD_SPEED_INDICATION_APP)) is not None:
         value = _speed_indication_to_save_fan_mode(readback)
         return None if value is None else float(value)
-    if (action := unit.registers.get(RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF)) is not None:
-        try:
-            return 0.0 if int(action) == 1 else float(action)
-        except (TypeError, ValueError):
-            return None
     value = _get_fan_mode_value(unit)
     return None if value is None else float(value)
 
@@ -218,8 +213,6 @@ def encode_homesolution_write_value(register: ModbusParameter, value: int) -> in
     """Translate SAVE Modbus command values for a selected HomeSolution control."""
     if register.boolean:
         return "true" if value else "false"
-    if register.short == "REG_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF" and value == 0:
-        return 1
     return value
 
 

--- a/custom_components/systemair/manifest.json
+++ b/custom_components/systemair/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4",
     "websocket-client"
   ],
-  "version": "1.0.32"
+  "version": "1.0.33"
 }

--- a/tests/test_homesolution_client.py
+++ b/tests/test_homesolution_client.py
@@ -157,6 +157,25 @@ class AlwaysWritableCatalog(FakeCatalog):
 class HomeSolutionClientTest(unittest.TestCase):
     """The cloud client polls all views independently of WebSocket state."""
 
+    def test_coordinator_calls_homesolution_through_the_shared_client_contract(self) -> None:
+        """HomeSolution accepts the alarm options passed to every Systemair client."""
+        client = SystemairHomeSolutionClient("user", "password", "device")
+        client.unit = VentilationUnit("device", "Unit")
+        client.unit.update_register_values({29: 3})
+        client._rate_limit_until = float("inf")
+
+        coordinator = SystemairDataUpdateCoordinator.__new__(SystemairDataUpdateCoordinator)
+        coordinator.client = client
+        coordinator.config_entry = SimpleNamespace(options={"enable_alarm_details": False, "enable_alarm_history": True})
+        coordinator._is_webapi = False
+
+        try:
+            unit = asyncio.run(coordinator._async_update_data())
+        except TypeError as err:
+            self.fail(f"HomeSolution get_all_data contract mismatch: {err}")
+
+        assert unit is client.unit
+
     def test_get_all_data_refreshes_catalog_and_restores_availability(self) -> None:
         """A partial view error preserves successful data and online state."""
         client = SystemairHomeSolutionClient("user", "password", "device")

--- a/tests/test_homesolution_mapping.py
+++ b/tests/test_homesolution_mapping.py
@@ -93,19 +93,21 @@ class HomeSolutionMappingTest(unittest.TestCase):
         unit.user_mode = 12
         assert resolver(unit, parameter_map["REG_USERMODE_MODE"]) == 12.0
 
-    def test_cloud_fan_stop_value_matches_save_climate_semantics(self) -> None:
-        """Action and readback IDs use their distinct airflow enumerations."""
+    def test_cloud_fan_setpoint_precedes_delayed_speed_indication(self) -> None:
+        """The selected fan mode updates immediately while actual airflow catches up."""
         resolver = homesolution_mapping.resolve_homesolution_value
         register = parameter_map["REG_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF"]
         unit = VentilationUnit("device", "Unit")
-        unit.registers[RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF] = 1
+        unit.registers[RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF] = 0
+        unit.registers[RegisterConstants.REG_MAINBOARD_SPEED_INDICATION_APP] = 4
 
         assert resolver(unit, register) == 0.0
 
-        unit.registers[RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF] = 2
-        assert resolver(unit, register) == 2.0
+        unit.registers[RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF] = 4
+        unit.registers[RegisterConstants.REG_MAINBOARD_SPEED_INDICATION_APP] = 2
+        assert resolver(unit, register) == 4.0
 
-        unit.registers.clear()
+        unit.registers.pop(RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF)
         unit.registers[RegisterConstants.REG_MAINBOARD_SPEED_INDICATION_APP] = 1
         assert resolver(unit, register) == 2.0
 
@@ -131,10 +133,10 @@ class HomeSolutionMappingTest(unittest.TestCase):
         )
         assert (
             capability(fan, RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF)
-            == RegisterConstants.REG_MAINBOARD_SPEED_INDICATION_APP
+            == RegisterConstants.REG_MAINBOARD_USERMODE_MANUAL_AIRFLOW_LEVEL_SAF
         )
         assert encode(mode, 4) == 4
-        assert encode(fan, 0) == 1
+        assert encode(fan, 0) == 0
         assert encode(fan, 3) == 3
         assert encode(eco, 1) == "true"
         assert encode(eco, 0) == "false"


### PR DESCRIPTION
## Summary
- restore the shared `get_all_data` keyword contract so HomeSolution coordinator polling no longer fails
- send the Cloud airflow `off` value as `0` and refresh/prefer the writable manual-airflow capability for immediate fan-mode state
- bump the integration version to `1.0.33`

## Affected connection modes
- HomeSolution Cloud only

## Test plan
- `py -3 -m unittest discover -s tests` — 133 tests passed
- Ruff, format, compileall, manifest JSON validation, and pre-commit passed
- live SAVE VSR 300 validation confirmed writable airflow values `0/2/3/4`, successful Cloud writes, and immediate manual-airflow readback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual fan airflow handling so setpoint changes take precedence over delayed speed indications.
  * Corrected fan airflow writes so a zero value is preserved accurately.
  * Updated client option handling for alarm details and history.

* **Tests**
  * Added coverage for shared client update behavior and manual fan setpoint resolution.

* **Chores**
  * Updated the integration version to 1.0.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->